### PR TITLE
Replace link to 404ed/dead pipeline instance links with VSM links

### DIFF
--- a/assets/js/factories/pipeline-chart-factories.js
+++ b/assets/js/factories/pipeline-chart-factories.js
@@ -36,7 +36,7 @@ export default new ChartFactories({
       const config = PipelineCharts.runs(data),
            factory = this;
 
-      GoCDLinkSupport.linkToPipelineInstance(config, transport);
+      GoCDLinkSupport.linkToVSMPage(config, transport);
 
       Utils.addOnLoad(config, function addBehaviors() {
         const chart = this;

--- a/assets/js/lib/gocd-link-support.js
+++ b/assets/js/lib/gocd-link-support.js
@@ -19,7 +19,6 @@ import _ from "lodash";
 const LINK_TO                    = "link_to";
 const JOB_DETAILS_LINK_KEY       = "job_details_page";
 const STAGE_DETAILS_LINK_KEY     = "stage_details_page";
-const PIPELINE_INSTANCE_LINK_KEY = "pipeline_instance_page";
 const VSM_LINK_KEY               = "vsm_page";
 
 const JOB_NAME_KEY         = "job_name";
@@ -71,16 +70,6 @@ const linkTo = {
     });
   },
 
-  pipelineInstance: (config, transport) => {
-    _.each(config.series, (s) => {
-      _.set(s, "point.events.click", (evt) => {
-        const params    = _.pick(evt.point, [PIPELINE_NAME_KEY, PIPELINE_COUNTER_KEY]);
-        params[LINK_TO] = PIPELINE_INSTANCE_LINK_KEY;
-        sendLinkRequest(transport, params);
-      });
-    });
-  },
-
   vsmPage: (config, transport) => {
     _.each(config.series, (s) => {
       _.set(s, "point.events.click", (evt) => {
@@ -100,10 +89,6 @@ function GoCDLinkSupport() {
 
   this.linkToStageDetailsPage = (config, transport) => {
     linkTo.stageDetailsPage(config, transport);
-  };
-
-  this.linkToPipelineInstance = (config, transport) => {
-    linkTo.pipelineInstance(config, transport);
   };
 
   this.linkToVSMPage = (config, transport) => {


### PR DESCRIPTION
- fixes #1308 

There is no direct replacement for the old Pipeline Instance page, removed many years ago, as this now works via modals on the main GoCD dashboard. The only page which has <pipelineName, pipelineCounter> as args is the VSM page, which is probably a reasonable alternative for now.

Later on a possible alternative would be a route which loads the specific page within pipeline activity corresponding to a given pipeline counter, but that would need GoCD server support.